### PR TITLE
Fix string equality

### DIFF
--- a/compiler-lib/src/libcore/foldmaths.rs
+++ b/compiler-lib/src/libcore/foldmaths.rs
@@ -1,4 +1,4 @@
-use crate::model::constants::{FullConstant, Constant};
+use crate::model::{constants::{FullConstant, Constant}, checkstypes::AtomicTypeSpec};
 use ordered_float::OrderedFloat;
 use super::util::{ arm, seq_flex, seq_flex_un, to_boolean, fold_num_bin};
 
@@ -179,10 +179,11 @@ pub(crate) fn fold_not(inputs: &[Option<FullConstant>]) -> Option<Vec<FullConsta
 
 pub(crate) fn fold_eq(inputs: &[Option<FullConstant>]) -> Option<Vec<FullConstant>> {
     if let (Some(Some(a)),Some(Some(b))) = (inputs.get(0),inputs.get(1)) {
-        Some(vec![number_pred!(|a,b| a==b,a,b)])
-    } else {
-        None
+        if let (Some(AtomicTypeSpec::Number),Some(AtomicTypeSpec::Number)) = (a.to_atomic_type(),b.to_atomic_type()) {
+            return Some(vec![number_pred!(|a,b| a==b,a,b)]);
+        }
     }
+    None
 }
 
 pub(crate) fn fold_any(inputs: &[Option<FullConstant>]) -> Option<Vec<FullConstant>> {

--- a/compiler-lib/src/model/constants.rs
+++ b/compiler-lib/src/model/constants.rs
@@ -81,6 +81,16 @@ pub enum FullConstant {
     Infinite(Constant)
 }
 
+impl FullConstant {
+    pub(crate) fn to_atomic_type(&self) -> Option<AtomicTypeSpec> {
+        match self {
+            FullConstant::Atomic(a) => Some(a.to_atomic_type()),
+            FullConstant::Finite(s) => s.get(0).map(|a| a.to_atomic_type()),
+            FullConstant::Infinite(a) => Some(a.to_atomic_type()),
+        }
+    }
+}
+
 impl fmt::Debug for FullConstant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/compiler-lib/src/test/testdata/compiler/handle.etf
+++ b/compiler-lib/src/test/testdata/compiler/handle.etf
@@ -60,4 +60,4 @@ cmp(a,b);
 
 >> narrow-fail strip
 
-cannot deduce type/B at sequences:152 (called from test:10) (called from test:14)
+cannot deduce type/B at sequences:170 (called from test:10) (called from test:14)

--- a/compiler-lib/src/test/testdata/libcore/libcore-regressions.etf
+++ b/compiler-lib/src/test/testdata/libcore/libcore-regressions.etf
@@ -98,3 +98,44 @@ opcode 10, r4, r5, r3
 opcode 137, r1
 opcode 137, r2
 
+>> test
+
+Fold numbers for ==
+
+>> input
+
+program "group" "program" 1;
+
+print(format(1 == 2));
+print(format([1,1] == [2,2]));
+
+>> generate strip
+
+r1 <- "false"
+opcode 137, r1
+r1 <- "[false,false]"
+opcode 137, r1
+
+>> test
+
+Don't fold non-numbers for ==
+
+>> input
+
+program "group" "program" 1;
+
+print(format("hello" == "world"));
+print(format(["hello","hello"] == ["world","world"]));
+
+>> generate strip
+
+r1 <- "hello"
+r2 <- "world"
+opcode 31, r3, r1, r2
+opcode 138, r1, r3
+opcode 137, r1
+r1 <- ["hello","hello"]
+r3 <- ["world","world"]
+opcode 37, r2, r1, r3
+opcode 138, r1, r2
+opcode 137, r1


### PR DESCRIPTION
A patch sent by Dan to fix an unexpected behaviour of the compiler when, due to optimisation, it made all strings to be equal to one another.

Example eard program:

```
program "ensembl-webteam/core" "equality" 1;
refer "libperegrine";
refer "libeoe";


print("is 1 equal to 2?");
print(format(1 == 2));
print("is 'Hello' equal to 'World'?");
print(format("Hello" == "World"));


let test_seq = ["foo", "bar", "baz", "quoxx"];
let is_bar = test_seq == "bar";
print(format(is_bar));

let new_seq = set(test_seq, is_bar, ["lol",...]);
print(format(new_seq));
```

produced the following results before the change (notice that string "Hello" is equal to string "World"; and string "bar" in is equal to all the other strings in the sequence:

```
is 1 equal to 2?
false
is 'Hello' equal to 'World'?
true
[true,true,true,true]
["lol","lol","lol","lol"]
```

Aftter Dan's change, the results of running this program are now this ("Hello" no longer equals to "World", and "bar" no longer equals other strings in the sequence):

```
is 1 equal to 2?
false
is 'Hello' equal to 'World'?
false
[false,true,false,false]
["foo","lol","baz","quoxx"]
```